### PR TITLE
Fix highlighting of with clauses

### DIFF
--- a/Syntaxes/Ada.plist
+++ b/Syntaxes/Ada.plist
@@ -92,7 +92,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>(^|[\r\n])((?i:((limited[ \t]*)?(private[ \t]*)?with))[ \t]+(\w+(\.\w+)*);[ \t]*)+</string>
+			<string>(?:^|[\r\n])(?:(?i:((?:limited[ \t]*)?(?:private[ \t]*)?with))[ \t]+(\w+(?:\.\w+)*);[ \t]*)+</string>
 			<key>name</key>
 			<string>meta.function.ada</string>
 		</dict>


### PR DESCRIPTION
This broke in ffedd9de2effb414d2fe4b322ae21cb8875ac7d8 when more capture groups were introduced. Now only the groups that we assign scopes to are capturing.
